### PR TITLE
Use optparse-applicative for argument parsing

### DIFF
--- a/mary.cabal
+++ b/mary.cabal
@@ -114,6 +114,7 @@ executable mary
                      , base >=4.9.1.0 && <4.14
                      , mary
                      , mtl >=2 && <3
+                     , optparse-applicative >= 0.13 && < 0.16
                      , pandoc-types >=1.19 && <1.21
                      , prettyprinter >=1.6 && <1.7
                      , text >=1.2 && <1.3

--- a/mary.hs
+++ b/mary.hs
@@ -1,10 +1,13 @@
 module Main where
 
+import Data.Semigroup ((<>))
 import Data.Text.IO as TIO
 
-import System.Environment
+import Text.Pandoc.JSON (toJSONFilter)
 
-import Text.Pandoc.JSON
+import Options.Applicative
+
+import System.Environment
 
 import Shonkier
 
@@ -13,16 +16,55 @@ import Mary.ServePage
 import Mary.ServeWeb
 
 main :: IO ()
-main = do
-  xs <- getArgs
-  case xs of
-    ["-pandoc"]               -> toJSONFilter process
-    ["-shonkier", filename]   -> interpretShonkier filename
-    ["-shonkierjs", filename] -> compileShonkier filename >>= TIO.putStrLn
-    ["-page", filename]       -> servePage testConfig filename >>= TIO.putStrLn
-    ["-web", pandoc, sitesRoot, user, page] -> do
-      mary    <- getExecutablePath
-      content <- serveWeb Config{..} sitesRoot user page
-      TIO.putStrLn content
-    _ -> TIO.putStr "# mary says\nI don't know what you're on about.\n\n"
+main = customExecParser (prefs showHelpOnEmpty) opts >>= \case
+  Pandoc              -> toJSONFilter process
+  Shonkier filename   -> interpretShonkier filename
+  Shonkierjs filename -> compileShonkier filename >>= TIO.putStrLn
+  Page filename       -> servePage testConfig filename >>= TIO.putStrLn
+  Web{..}             -> do
+    mary    <- getExecutablePath
+    content <- serveWeb Config{..} sitesRoot user page
+    TIO.putStrLn content
+  where
+    opts = info (optsParser <**> helper)
+      ( fullDesc
+     <> header "Mary - a content delivery and assessment engine")
 
+data Options
+  = Pandoc
+  | Shonkier   { filename :: String }
+  | Shonkierjs { filename :: String }
+  | Page       { filename :: String }
+  | Web        { pandoc    :: String
+               , sitesRoot :: String
+               , user      :: String
+               , page      :: String
+               }
+
+optsParser :: Parser Options
+optsParser = subparser
+  ( command' "pandoc"
+             (pure Pandoc)
+             "Act as a Pandoc filter"
+ <> command' "shonkier"
+             (Shonkier <$> strArgument
+                (metavar "FILE" <> action "file" <> help "Input Shonkier program."))
+             "Interpret shonkier program"
+ <> command' "shonkierjs"
+             (Shonkierjs <$> strArgument
+                  (metavar "FILE" <> action "file" <> help "Source Shonkier program."))
+             "Compile shonkier program to javascript"
+ <> command' "page"
+             (Page <$> strArgument
+                  (metavar "FILE" <> action "file" <> help "Input Mary file"))
+             "Generate HTML from Mary file"
+ <> command' "web"
+             (Web <$> strArgument (metavar "PANDOC" <> action "file" <> help "Path to pandoc.")
+                  <*> strArgument (metavar "ROOT" <> action "directory" <> help "Path to site root.")
+                  <*> strArgument (metavar "USER" <> action "user" <> help "Username.")
+                  <*> strArgument (metavar "PAGE" <> action "file" <> help "Page to serve."))
+             "Serve webpage")
+  where
+    command' :: String -> Parser a -> String -> Mod CommandFields a
+    command' label parser description =
+      command label (info parser (progDesc description))

--- a/src/Mary/ServePage.hs
+++ b/src/Mary/ServePage.hs
@@ -23,7 +23,7 @@ servePage Config{..} inp =
   withCreateProcess ((proc pandoc ["-s", inp, "-f", "markdown", "-t", "json"])
                      { std_out = CreatePipe
                      }) $ \ _ (Just hpandoc) _ _ ->
-  withCreateProcess ((proc mary ["-pandoc"])
+  withCreateProcess ((proc mary ["pandoc"])
                      { std_in  = UseHandle hpandoc
                      , std_out = CreatePipe
                      }) $ \ _ (Just hmary) _ _ ->

--- a/test/Test/Shonkier.hs
+++ b/test/Test/Shonkier.hs
@@ -10,7 +10,7 @@ import Test.Tasty (TestTree)
 import Test.Utils
 
 shonkier :: FilePath -> IO Text
-shonkier inp = T.pack <$> readProcess "mary" ["-shonkier", inp] ""
+shonkier inp = T.pack <$> readProcess "mary" ["shonkier", inp] ""
 
 shonkierTests :: IO TestTree
 shonkierTests = do
@@ -23,7 +23,7 @@ shonkierTests = do
 
 shonkierJS :: FilePath -> IO Text
 shonkierJS inp =
-  withCreateProcess ((proc "mary" ["-shonkierjs", inp])
+  withCreateProcess ((proc "mary" ["shonkierjs", inp])
                      { std_out = CreatePipe
                      }) $ \ _ (Just hmary) _ _ ->
   withCreateProcess ((proc "node" ["-"])


### PR DESCRIPTION
Getting the boilerplate in now so that it is managable in the future.

One change is that the syntax is forced to change from e.g. `mary -shonkier foo.shonkier` to `mary shonkier foo.shonkier` (i.e. without the dash), but I hope that is okay.