### PR TITLE
[ new ] relative links, and pub support

### DIFF
--- a/examples/links.mary
+++ b/examples/links.mary
@@ -1,0 +1,9 @@
+# Links
+
+Here is an [absolute link](https://twitter.com/TheMERL/status/983341970318938112). This one is [all relative](hello.mary), you know? And these ones are [complicated](subfolder/../enum.mary) [for no](~/enum.mary) [good reason](../././enum.mary).
+
+And here are some images:
+
+![That ram again](https://twitter.com/TheMERL/status/983341970318938112/photo/1)
+
+![A pub relative image](pub/doesntActuallyExist.jpg)

--- a/index.php
+++ b/index.php
@@ -1,37 +1,70 @@
 <?php
 
-$user_id = escapeshellarg($_SERVER['HTTP_CIS_REMOTE_USER']);
-$page_id = escapeshellarg($_GET["page"]);
+$site_root = "../MarySites/";
 
-$descriptorspec = array(
-   0 => array("pipe", "r"),  // stdin is a pipe that the child will read from
-   1 => array("pipe", "w"),  // stdout is a pipe that the child will write to
-   2 => array("file", "/tmp/error-output.txt", "a") // stderr is a file to write to
-);
+if (filter_has_var(INPUT_GET, "page")) {
 
-$cmd = "./mary find $user_id ../MarySites/ $page_id | ./pandoc --data-dir=data --standalone -f markdown --filter=marypandoc -t html --template templates/mary.html5 2>&1";
+  $user_id = escapeshellarg($_SERVER['HTTP_CIS_REMOTE_USER']);
+  $page_id = escapeshellarg($_GET["page"]);
 
-$cwd = NULL;
-$env = NULL;
 
-$process = proc_open($cmd, $descriptorspec, $pipes, $cwd, $env);
+  $descriptorspec = array(
+     0 => array("pipe", "r"),  // stdin is a pipe that the child will read from
+     1 => array("pipe", "w"),  // stdout is a pipe that the child will write to
+     2 => array("file", "/tmp/error-output.txt", "a") // stderr is a file to write to
+  );
 
-if (is_resource($process)) {
-    // $pipes now looks like this:
-    // 0 => writeable handle connected to child stdin
-    // 1 => readable handle connected to child stdout
-    // Any error output will be appended to /tmp/error-output.txt
+  $cmd = "./mary find $user_id $site_root $page_id | ./pandoc --data-dir=data --standalone -f markdown --filter=marypandoc -t html --template templates/mary.html5 2>&1";
 
-    fwrite($pipes[0], serialize($_POST));
-    fwrite($pipes[0], serialize($_GET));
-    fclose($pipes[0]);
+  $cwd = NULL;
+  $env = NULL;
 
-    echo stream_get_contents($pipes[1]);
-    fclose($pipes[1]);
+  $process = proc_open($cmd, $descriptorspec, $pipes, $cwd, $env);
 
-    // It is important that you close any pipes before calling
-    // proc_close in order to avoid a deadlock
-    $return_value = proc_close($process);
-};
+  if (is_resource($process)) {
+      // $pipes now looks like this:
+      // 0 => writeable handle connected to child stdin
+      // 1 => readable handle connected to child stdout
+      // Any error output will be appended to /tmp/error-output.txt
 
+      fwrite($pipes[0], serialize($_POST));
+      fwrite($pipes[0], serialize($_GET));
+      fclose($pipes[0]);
+
+      echo stream_get_contents($pipes[1]);
+      fclose($pipes[1]);
+
+      // It is important that you close any pipes before calling
+      // proc_close in order to avoid a deadlock
+      $return_value = proc_close($process);
+  }
+}
+elseif (filter_has_var(INPUT_GET, "pub")) {
+  $pub_id = filter_input(INPUT_GET, 'pub', FILTER_SANITIZE_SPECIAL_CHARS);
+  $target = realpath($site_root . "/" . $pub_id);
+  echo $target;
+  if (!$target) {
+    // realpath returns false if the target does not exist.
+    trigger_error("Specified file does not exist.", E_USER_ERROR);
+  }
+  elseif (strpos($target, "/pub/") === FALSE) {
+    // The user asked for a file not in a pub directory; we cannot
+    // allow this! We use the same error message here as above in
+    // order to not leak information.
+    trigger_error("Specified file does not exist.", E_USER_ERROR);
+  }
+  elseif (!(strpos($target, realpath($site_root)) === 0)) {
+    // The user is trying to access a file outside the site root!
+    trigger_error("Specified file does not exist.", E_USER_ERROR);
+  }
+  else {
+      // We are good, ship the file!
+      $mime_type = mime_content_type($target);
+      //header('Content-Type: '.$mime_type);
+      //readfile($target);
+  }
+}
+else {
+  trigger_error("No page or pub given", E_USER_ERROR);
+}
 ?>

--- a/mary.hs
+++ b/mary.hs
@@ -7,8 +7,6 @@ import Text.Pandoc.JSON (toJSONFilter)
 
 import Options.Applicative
 
-import System.Environment
-
 import Shonkier
 
 import Mary.Pandoc

--- a/src/Mary/Pandoc.hs
+++ b/src/Mary/Pandoc.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Mary.Pandoc where
 
 import Control.Monad.Writer (Writer, runWriter, tell)
@@ -5,12 +6,15 @@ import Control.Newtype
 
 import Data.Attoparsec.Text
 import Data.Foldable
+import Data.List as L
 import Data.Maybe
 import Data.Monoid
-import Data.Text (Text)
+import Data.Text as T
 
 import Text.Pandoc.Builder
 import Text.Pandoc.Walk
+
+import System.FilePath
 
 import Shonkier.Parser
 import Shonkier.Value
@@ -20,14 +24,18 @@ import Shonkier.Semantics
 import Shonkier.ShonkierJS
 
 process :: Pandoc -> IO Pandoc
-process doc0 = do
+process doc0@(Pandoc meta docs) = do
   let (doc1, defns) = runWriter (walkM snarfMaryDef doc0)
   let rm@(is, ps)  = fold [ (is, p)
                           | ds <- defns
                           , let Right (is, p) = parseOnly module_ ds
                           ]
   (mod, env) <- loadToplevelModule "." rm
-  let doc2 = walk (evalMaryInline is env)
+  -- we assume that there is page metadata, put there by mary find
+  let page = case lookupMeta "page" meta of
+        Just (MetaInlines [Str s]) -> s
+        _ -> error "Meta data 'page' missing!"
+  let doc2 = walk (evalMaryInline is env page)
            . walk (evalMaryBlock is env)
            $ doc1
   pure $ setTitle (fromMaybe "Title TBA" (ala' First query h1 doc0))
@@ -58,14 +66,49 @@ evalMaryBlock is env (CodeBlock (_, cs, _) e) | "mary" `elem` cs =
       _ -> Null
 evalMaryBlock _ _ b = b
 
-evalMaryInline :: [Import] -> GlobalEnv -> Inline -> Inline
-evalMaryInline is env (Code (_, cs, _) e) | "mary" `elem` cs =
+evalMaryInline :: [Import] -> GlobalEnv -> Text -> Inline -> Inline
+evalMaryInline is env page (Code (_, cs, _) e) | elem "mary" cs =
   case parseOnly (term <* endOfInput) e of
     Left _ -> Space
     Right t -> case rawShonkier is env t of
       Value v -> fromValue v
       _ -> Space
-evalMaryInline _ _ b = b
+evalMaryInline _ _ page (Link attrs is target) =
+  Link attrs is (makeAbsolute page target)
+evalMaryInline _ _ page (Image attrs is target) =
+  Image attrs is (makeAbsolute page target)
+evalMaryInline _ _ _ b = b
+
+makeAbsolute :: Text -> Target -> Target
+makeAbsolute page (url, title) = (absUrl, title)
+  where
+    baseURL = "https://personal.cis.strath.ac.uk/conor.mcbride/shib/Mary/"
+    absUrl = if isAbsolute url then -- keep it as is
+              url
+             else
+               T.concat $ [baseURL, thing , "=", newUrl]
+    thing = if isPub url then "?pub" else "?page"
+    -- if current page is eg repo/lectures/bonus/two.md and requested
+    -- URL is eg ../../basic/notes.pdf, new URL is repo/basic/notes.pdf
+    newUrl = joinPathT $ normalise (L.init (splitOn "/" page))
+                                   (L.filter (/= ".")  (splitOn "/" url))
+
+    isAbsolute t = or (fmap (flip T.isPrefixOf t)
+                        ["https://", "http://", "ftp://", "//", "mailto:", "tel:"]) -- TODO: make more generic?
+    isPub t      = ("pub/" `T.isPrefixOf` t || "/pub/" `T.isInfixOf` t)
+                     && (not $ "pub/" `T.isSuffixOf` t)
+
+    normalise :: [Text] -> [Text] -> [Text]
+    normalise (site:_) ("~":us) = normalise [site] us -- '~' => "from site root"
+    normalise (site:ps) us = site:go (L.reverse ps) us -- keep site root always
+      where
+        go sp [] = L.reverse sp
+        go (_:sp) ("..":us) = go sp us
+        go []     ("..":us) = go [] us -- allowing overshooting
+        go sp     (p:us)    = go (p:sp) us
+    normalise [] _ = error "IMPOSSIBLE: empty page"
+
+    joinPathT = T.pack . joinPath . fmap T.unpack
 
 listy :: (FromValue a) => ([a] -> b) -> Value -> b
 listy = (. fromValue)

--- a/src/Mary/Pandoc.hs
+++ b/src/Mary/Pandoc.hs
@@ -67,7 +67,7 @@ evalMaryBlock is env (CodeBlock (_, cs, _) e) | "mary" `elem` cs =
 evalMaryBlock _ _ b = b
 
 evalMaryInline :: [Import] -> GlobalEnv -> Text -> Inline -> Inline
-evalMaryInline is env page (Code (_, cs, _) e) | elem "mary" cs =
+evalMaryInline is env page (Code (_, cs, _) e) | "mary" `elem` cs =
   case parseOnly (term <* endOfInput) e of
     Left _ -> Space
     Right t -> case rawShonkier is env t of
@@ -86,14 +86,14 @@ makeAbsolute page (url, title) = (absUrl, title)
     absUrl = if isAbsolute url then -- keep it as is
               url
              else
-               T.concat $ [baseURL, thing , "=", newUrl]
+               T.concat [baseURL, thing, "=", newUrl]
     thing = if isPub url then "?pub" else "?page"
     -- if current page is eg repo/lectures/bonus/two.md and requested
     -- URL is eg ../../basic/notes.pdf, new URL is repo/basic/notes.pdf
     newUrl = joinPathT $ normalise (L.init (splitOn "/" page))
                                    (L.filter (/= ".")  (splitOn "/" url))
 
-    isAbsolute t = or (fmap (flip T.isPrefixOf t)
+    isAbsolute t = or (fmap (`T.isPrefixOf` t)
                         ["https://", "http://", "ftp://", "//", "mailto:", "tel:"]) -- TODO: make more generic?
     isPub t      = ("pub/" `T.isPrefixOf` t || "/pub/" `T.isInfixOf` t)
                      && (not $ "pub/" `T.isSuffixOf` t)

--- a/test/Test/Mary.hs
+++ b/test/Test/Mary.hs
@@ -10,4 +10,6 @@ maryTests = do
   let name      = "Mary"
   let extension = ".mary"
   let goldenExt = ".gold"
-  ioTests TestConfig{..} (servePage testConfig) []
+  ioTests TestConfig{..} (servePage testConfig)
+    -- excluded tests
+    ["./examples/links.mary"] -- test pipeline does not get page metavalue


### PR DESCRIPTION
Detects relative links and expands them to links to `https://personal.cis.strath.ac.uk/conor.mcbride/shib/Mary/?page=...` or `https://personal.cis.strath.ac.uk/conor.mcbride/shib/Mary/?pub=...` as appropriate.

Adds `?pub` functionality to index.php: will output the contents of the given file, as long as it is under the site root, and in a pub directory.

The new Mary test case is disabled, since the servepage route used in the test framework does not get the page metavalue from `mary find`.